### PR TITLE
Change mentions of `shardeum` to `liberdus`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -35,7 +35,7 @@ further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abuse, harassment, or otherwise unacceptable behavior may be reported by contacting <codeofconduct@shardeum.org>. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abuse, harassment, or otherwise unacceptable behavior may be reported by contacting <codeofconduct@liberdus.com>. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.md
+++ b/README.md
@@ -17,21 +17,21 @@ Before diving into the Validator CLI, ensure you have the following:
 ### 1. Clone the Repository
 
 ```bash
-git clone git@github.com:shardeum/validator-cli.git
+git clone git@github.com:liberdus/validator-cli.git
 cd validator-cli
 ```
 
 ### 2. Set Up Symlink (Local Network Only)
 
-When running a local network, the Validator CLI requires a symlink to the locally running Liberdus repository. 
+When running a local network, the Validator CLI requires a symlink to the locally running Liberdus repository.
 Create the symlink by running this command in the cli directory:
 
 ```bash
-ln -s /path/to/shardeum/repo ../validator
+ln -s /path/to/liberdus/repo ../validator
 ls ../validator  # Verify the symlink
 ```
 
-Replace `/path/to/shardeum/repo` with the actual path to your local Liberdus repository.
+Replace `/path/to/liberdus/repo` with the actual path to your local Liberdus repository.
 
 ### 3. Install Dependencies
 
@@ -155,10 +155,10 @@ We welcome contributions to the Liberdus Validator CLI! Please adhere to our [co
 ## Community and Support
 
 - For discussions and searchable conversations:
-  [Liberdus GitHub Discussions](https://github.com/shardeum/shardeum/discussions)
+  [Liberdus GitHub Discussions](https://github.com/liberdus/liberdus/discussions)
 
 - For real-time chat and community interaction:
-  [Liberdus Discord Server](https://discord.com/invite/shardeum)
+  [Liberdus Discord Server](https://discord.com/invite/liberdus)
 
 ## License
 

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -470,7 +470,7 @@ export function registerNodeCommands(program: Command) {
         `node`,
         [`${path.join(__dirname, VALIDATOR_CLEAN_PATH)}`],
         () => {
-          // Exec PM2 to start the shardeum validator
+          // Exec PM2 to start the liberdus validator
           pm2.connect(err => {
             if (err) {
               console.error(err);
@@ -532,7 +532,7 @@ export function registerNodeCommands(program: Command) {
         });
       }
 
-      // Exec PM2 to stop the shardeum validator
+      // Exec PM2 to stop the liberdus validator
       pm2.connect(err => {
         if (err) {
           console.error(err);

--- a/src/utils/fetch-node-data.ts
+++ b/src/utils/fetch-node-data.ts
@@ -21,7 +21,7 @@ export async function getExitInformation() {
 
   const interceptExitMessage = (message: string) => {
     if (message.includes('Fatal: submitJoin: our node')) {
-      return 'Unable to access external or internal ports. Please provide proper port access to the external and internal ports of shardeum  (9001 / 10001 are the defaults)';
+      return 'Unable to access external or internal ports. Please provide proper port access to the external and internal ports of Liberdus  (9001 / 10001 are the defaults)';
     }
     return message;
   };

--- a/src/utils/project-data.ts
+++ b/src/utils/project-data.ts
@@ -9,13 +9,13 @@ const GUI_LOCAL_PATH = path.join(__dirname, '../../../../gui');
 const VALIDATOR_LOCAL_PATH = path.join(__dirname, '../../../../validator');
 
 export async function getLatestCliVersion() {
-  const packageJsonURI = `https://raw.githubusercontent.com/shardeum/validator-cli/dev/package.json`;
+  const packageJsonURI = `https://raw.githubusercontent.com/liberdus/validator-cli/dev/package.json`;
   const json = await axios.get<{version: string}>(packageJsonURI);
   return json.data.version;
 }
 
 export async function getLatestGuiVersion() {
-  const packageJsonURI = `https://raw.githubusercontent.com/shardeum/validator-gui/dev/package.json`;
+  const packageJsonURI = `https://raw.githubusercontent.com/liberdus/validator-gui/dev/package.json`;
   const json = await axios.get<{version: string}>(packageJsonURI);
   return json.data.version;
 }

--- a/update.sh
+++ b/update.sh
@@ -27,7 +27,7 @@ dry_run() {
   rm -rf tmp
   mkdir tmp
   cd tmp || exit
-  git clone https://github.com/shardeum/validator-cli.git cli
+  git clone https://github.com/liberdus/validator-cli.git cli
   cd cli || exit
   if npm install && npm run compile; then
     echo 'Dry run update successful'


### PR DESCRIPTION
Some URLs will need to be checked. For example, there is no custom Discord link for Liberdus. If necessary, email inboxes should be set up as well for any email addresses mentioned here.